### PR TITLE
refactor(agent): wraprec fix cleanup

### DIFF
--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -793,59 +793,6 @@ extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
 
-#define NR_ZEND_USER_FUNC_EXISTS(x) \
-  (x && (!x->func || !ZEND_USER_CODE(x->func->type)))
-
-/*
- * Purpose : Return a pointer to the function name of zend_execute_data.
- *
- * Params  : 1. zend_execute_data.
- *
- * Returns : A pointer to string, ownership of does NOT pass to the caller and
- *           string must be dupped if it needs to persist,
- *           or NULL if the zend_execute_data is invalid.
- *
- */
-extern const char* nr_php_zend_execute_data_function_name(
-    const zend_execute_data* execute_data);
-/*
- * Purpose : Return a pointer to the filename of zend_execute_data.
- *
- * Params  : 1. zend_execute_data.
- *
- * Returns : A pointer to string, ownership of does NOT pass to the caller and
- *           string must be dupped if it needs to persist,
- *           or NULL if the zend_execute_data is invalid.
- *
- */
-extern const char* nr_php_zend_execute_data_filename(
-    const zend_execute_data* execute_data);
-
-/*
- * Purpose : Return a pointer to the scope(i.e., class) name of
- * zend_execute_data.
- *
- * Params  : 1. zend_execute_data.
- *
- * Returns : A pointer to string, ownership of does NOT pass to the caller and
- *           string must be dupped if it needs to persist,
- *           or NULL if the zend_execute_data is invalid.
- *
- */
-extern const char* nr_php_zend_execute_data_scope_name(
-    const zend_execute_data* execute_data);
-
-/*
- * Purpose : Return a uint32_t line number value of zend_execute_data.
- *
- * Params  : 1. zend_execute_data.
- *
- * Returns : uint32_t lineno value
- *
- */
-extern uint32_t nr_php_zend_execute_data_lineno(
-    const zend_execute_data* execute_data);
-
 /*
  * Purpose : Return a uint32_t (zend_uint) line number value of zend_function.
  *

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -48,14 +48,11 @@
  * Many functions here call zend_bailout to continue handling fatal PHP errors,
  * Since zend_bailout calls longjmp it never returns.
  *
- * Note: The agent ONLY needs to call this if it has overwritten the original
- * zend_execute_ex.
  */
 int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
   volatile int zcaught = 0;
   zend_try {
-    NR_PHP_PROCESS_GLOBALS(orig_execute)
-    (NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   }
   zend_catch { zcaught = 1; }
   zend_end_try();
@@ -71,8 +68,7 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
       wraprec->special_instrumentation(wraprec, segment,
                                        NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     } else {
-      NR_PHP_PROCESS_GLOBALS(orig_execute)
-      (NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+      NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     }
   }
   zend_catch { zcaught = 1; }
@@ -635,10 +631,6 @@ void nr_php_destroy_user_wrap_records(void) {
  */
 nruserfn_t* nr_wrapped_user_functions = 0;
 
-/*
- * nr_php_user_function_add_declared_callback is ONLY called from drupal for
- * PHP < 7.3.  It does not need to be adjusted for OAPI.
- */
 void nr_php_user_function_add_declared_callback(const char* namestr,
                                                 int namestrlen,
                                                 nruserfn_declared_t callback

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -308,15 +308,17 @@ static void nr_php_add_custom_tracer_common(nruserfn_t* wraprec) {
   nr_wrapped_user_functions = wraprec;
 }
 
-bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
-#if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO
-  /*
-   * Not compatible with PHP less than 7.
-   */
-  (void)func;
-  (void)p;
-  return false;
-#else
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+/*
+ * Purpose : Determine if a func matches a wraprec.
+ *
+ * Params  : 1. The wraprec to match to a zend function
+ *           2. The zend function to match to a wraprec
+ *
+ * Returns : True if the class/function of a wraprec match the class function
+ *           of a zend function.
+ */
+static bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
   char* klass = NULL;
   const char* filename = NULL;
 
@@ -399,17 +401,9 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
     return true;
   }
   return false;
-#endif
 }
 
 nruserfn_t* nr_php_get_wraprec_by_func(zend_function* func) {
-#if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO
-  /*
-   * Not compatible with PHP less than 7.
-   */
-  (void)func;
-  return NULL;
-#else
   nruserfn_t* p = NULL;
 
   if ((NULL == func) || (ZEND_USER_FUNCTION != func->type)) {
@@ -426,8 +420,8 @@ nruserfn_t* nr_php_get_wraprec_by_func(zend_function* func) {
   }
 
   return NULL;
-#endif
 }
+#endif
 
 #define NR_PHP_UNKNOWN_FUNCTION_NAME "{unknown}"
 nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -103,17 +103,7 @@ typedef struct _nruserfn_t {
 
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
 
-/*
- * Purpose : Determine if a func matches a wraprec.
- *
- * Params  : 1. The wraprec to match to a zend function
- *           2. The zend function to match to a wraprec
- *
- * Returns : True if the class/function of a wraprec match the class function
- *           of a zend function.
- */
-extern bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func);
-
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
 /*
  * Purpose : Get the wraprec stored in nr_wrapped_user_functions and associated
  *           with a zend_function.
@@ -127,7 +117,7 @@ extern bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func);
  *           NULL if no function wrapper matches the zend_function.
  */
 extern nruserfn_t* nr_php_get_wraprec_by_func(zend_function* func);
-
+#endif
 /*
  * Purpose : Get the wraprec associated with a user function op_array.
  *

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -81,9 +81,6 @@ typedef struct _nruserfn_t {
    */
   nrspecialfn_t special_instrumentation;
 
-  /*
-   * Only for PHP < 7.3
-   */
   nruserfn_declared_t declared_callback;
 
   int is_method;

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -182,20 +182,6 @@ typedef struct _nr_segment_t {
                                                       external or datastore
                                                       segments. */
   nr_segment_error_t* error; /* segment error attributes */
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-
-  /*
-   * Because of the access to the segment is now split between functions, we
-   * need to pass a certain amount of data between the functions that use the
-   * segment.
-   */
-  nrtime_t txn_start_time; /* To doublecheck the txn is correct when it is time
-                              to add the segment to the txn. */
-  void* wraprec; /* wraprec, if one is associated with this segment, to reduce
-                    wraprec lookups */
-
-#endif
-
 } nr_segment_t;
 
 /*


### PR DESCRIPTION
The wraprec fix PR ([#568](https://github.com/newrelic/newrelic-php-agent/pull/568)) includes unrelated changes from observer api and code level metrics. This update removes those unrelated changes as well as improves the implementation by not exporting `nr_php_wraprec_matches` helper function and compiling  wraprec fix only only when building for PHPs 7.4+.